### PR TITLE
Fixed Asterisk Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Invalid key: `this is an.invalidkey.🍕.4.5.6.7.8.9.10.11.12.13.14.15.16.17.18`
 ### Wildcards in Keys
 Suppose a developer wishes to listen to a subset of the tree containing multiple nodes, CSync provides this ability through wildcards. Currently CSync supports `*` and `#` as wildcards.
 
-#### Astrix Wildcard
-An astrix (`*`) wildcard will match any value in the part of the key where the wildcard is. As an example, if a developer listens to `companies.*.stock` in the above tree, the client will sync with all stock nodes for all companies.
+#### Asterisk Wildcard
+An Asterisk (`*`) wildcard will match any value in the part of the key where the wildcard is. As an example, if a developer listens to `companies.*.stock` in the above tree, the client will sync with all stock nodes for all companies.
 
 #### Hash Wildcard
 If a developer wishes to listen to all child nodes in a subset of the tree, the `#` can appended to the end of a key and the client will sync with all child nodes of the specified key. For instance in the above tree if a user listens to `companies.ibm.#`, then the client will sync with all child nodes of `companies.ibm` which include `companies.ibm.stock` and `companies.ibm.offices`.


### PR DESCRIPTION
Resolves #16 
DCO1.1 Signed-off-by: Thomas Boop <tgboop@us.ibm.com>